### PR TITLE
Bugfix in mounting the postgres volume

### DIFF
--- a/acme-pay-account-service/docker-compose.yml
+++ b/acme-pay-account-service/docker-compose.yml
@@ -9,6 +9,6 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_DB=account-service
     volumes:
-      - "./data/accounts/postgres:/var/lib/postgres/data"
+      - "./data/accounts/postgres:/var/lib/postgresql/data"
     ports:
       - 5433:5432


### PR DESCRIPTION
O caminho correto para fazer o mapeamento dos arquivos do banco postgres é: '/var/lib/postgresql/data'

A informação pode ser observada na sessão PGDATA da página da imagem oficial do Postgres no docker hub:
https://hub.docker.com/_/postgres